### PR TITLE
Ajusta lógica de Copiar URL

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -16,6 +16,8 @@ import { ContainerRow } from "../components/styles";
 
 import RequestJson from "../components/RequestJson";
 
+import ForceReloadDataProvider from "../contexts/ForceReloadData";
+
 function useQuery() {
   return new URLSearchParams(useLocation().search);
 }
@@ -117,60 +119,61 @@ function App() {
           </ContainerFlexWidthCustom>
         </ContainerRow>
       )}
+      <ForceReloadDataProvider>
+        <Container>
+          <Form
+            dataDefault={dataDefault}
+            base_url={base_url}
+            setBaseUrl={setBaseUrl}
+            gateway_token={gateway_token}
+            setGateway_token={setGateway_token}
+            data={data}
+            setUrlGenerated={setUrlGenerated}
+            handleGenerateURL={() => handleGenerateSignature()}
+            setData={setData}
+            typeFormSelected={typeFormSelected}
+          />
+          <ContainerResult>
+            {urlGenerated && (
+              <>
+                {typeFormSelected === "url" && (
+                  <RequestJson
+                    type={typeFormSelected}
+                    style={{ marginBottom: 20 }}
+                    urlGateway={urlGateway}
+                    label="URL to Gateway Web:"
+                    textButton="Open URL Gateway"
+                  />
+                )}
 
-      <Container>
-        <Form
-          dataDefault={dataDefault}
-          base_url={base_url}
-          setBaseUrl={setBaseUrl}
-          gateway_token={gateway_token}
-          setGateway_token={setGateway_token}
-          data={data}
-          setUrlGenerated={setUrlGenerated}
-          handleGenerateURL={() => handleGenerateSignature()}
-          setData={setData}
-          typeFormSelected={typeFormSelected}
-        />
-        <ContainerResult>
-          {urlGenerated && (
-            <>
-              {typeFormSelected === "url" && (
-                <RequestJson
-                  type={typeFormSelected}
-                  style={{ marginBottom: 20 }}
-                  urlGateway={urlGateway}
-                  label="URL to Gateway Web:"
-                  textButton="Open URL Gateway"
-                />
-              )}
-
-              {typeFormSelected === "json" && (
-                <RequestJson
-                  type={typeFormSelected}
-                  style={{ marginBottom: 20 }}
-                  dataRequest={data}
-                  url={url}
-                  label="JSON Post Request:"
-                  textButton="Copy JSON"
-                />
-              )}
-            </>
-          )}
-          <CustomButton
-            size="large"
-            onClick={() => handleGenerateSignature()}
-            style={{
-              width: "100%",
-              textTransform: "none",
-              minWidth: "100%",
-              marginRight: 0,
-            }}
-            variant="contained"
-          >
-            {`Generate ${typeFormSelected.toUpperCase()}`}
-          </CustomButton>
-        </ContainerResult>
-      </Container>
+                {typeFormSelected === "json" && (
+                  <RequestJson
+                    type={typeFormSelected}
+                    style={{ marginBottom: 20 }}
+                    dataRequest={data}
+                    url={url}
+                    label="JSON Post Request:"
+                    textButton="Copy JSON"
+                  />
+                )}
+              </>
+            )}
+            <CustomButton
+              size="large"
+              onClick={() => handleGenerateSignature()}
+              style={{
+                width: "100%",
+                textTransform: "none",
+                minWidth: "100%",
+                marginRight: 0,
+              }}
+              variant="contained"
+            >
+              {`Generate ${typeFormSelected.toUpperCase()}`}
+            </CustomButton>
+          </ContainerResult>
+        </Container>
+      </ForceReloadDataProvider>
     </>
   );
 }

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -181,8 +181,6 @@ function Form({
     logo_url,
   ]);
 
-  console.log(disable, setDisable);
-
   function handleReloadRandomFormatData() {
     setMerchantTransactionId(getRandomMerchantTransactionId());
     setDisable(false);

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -177,7 +177,7 @@ function Form({
     logo_url,
   ]);
 
-  function handleReloadRandomFormtData() {
+  function handleReloadRandomFormatData() {
     setMerchantTransactionId(getRandomMerchantTransactionId());
   }
 
@@ -193,7 +193,7 @@ function Form({
         </ContainerFlexWidthCustom>
         <ContainerFlexWidthCustom widthPercent={50} style={{}}>
           <Button
-            onClick={() => handleReloadRandomFormtData()}
+            onClick={() => handleReloadRandomFormatData()}
             style={{
               width: "100%",
               textTransform: "none",

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -19,6 +19,8 @@ import { PixKeyTypes } from "../../utils/pixKeyTypes";
 
 import { getRandomMerchantTransactionId } from "../../utils/generatePropsRandom";
 
+import { useForceReloadData } from "../../contexts/ForceReloadData";
+
 function Form({
   setData,
   setGateway_token,
@@ -65,6 +67,8 @@ function Form({
   const [login_email, setLoginEmail] = React.useState(dataDefault.email);
   const [password, setPassword] = React.useState("123123123");
   const [logo_url, setLogoUrl] = React.useState(logo_url_example);
+
+  const { disable, setDisable } = useForceReloadData();
 
   function setTypesChecked(typeKey, isChecked) {
     const newTypesCheckeds = { ...typesCheckeds, [typeKey]: isChecked };
@@ -177,8 +181,11 @@ function Form({
     logo_url,
   ]);
 
+  console.log(disable, setDisable);
+
   function handleReloadRandomFormatData() {
     setMerchantTransactionId(getRandomMerchantTransactionId());
+    setDisable(false);
   }
 
   return (
@@ -198,7 +205,8 @@ function Form({
               width: "100%",
               textTransform: "none",
             }}
-            variant="outlined"
+            variant={disable === true ? "contained" : "outlined"}
+            color="success"
           >
             Reload Random Data
           </Button>

--- a/src/components/RequestJson/index.js
+++ b/src/components/RequestJson/index.js
@@ -20,7 +20,7 @@ import {
 import { ContainerRow } from "../styles";
 
 import { useForceReloadData } from "../../contexts/ForceReloadData";
-// comment
+// comment de novo
 function RequestJson({
   dataRequest,
   url,

--- a/src/components/RequestJson/index.js
+++ b/src/components/RequestJson/index.js
@@ -19,6 +19,8 @@ import {
 } from "./styles";
 import { ContainerRow } from "../styles";
 
+import { useForceReloadData } from "../../contexts/ForceReloadData";
+
 function RequestJson({
   dataRequest,
   url,
@@ -28,7 +30,9 @@ function RequestJson({
   type,
   ...rest
 }) {
-  const [disable, setDisable] = useState(false);
+  const { disable, setDisable } = useForceReloadData();
+
+  console.log(disable);
 
   function handleCopyToClipboard() {
     if (!disable) {

--- a/src/components/RequestJson/index.js
+++ b/src/components/RequestJson/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import "react-notifications/lib/notifications.css";
@@ -31,8 +31,6 @@ function RequestJson({
   ...rest
 }) {
   const { disable, setDisable } = useForceReloadData();
-
-  console.log(disable);
 
   function handleCopyToClipboard() {
     if (!disable) {

--- a/src/components/RequestJson/index.js
+++ b/src/components/RequestJson/index.js
@@ -20,7 +20,7 @@ import {
 import { ContainerRow } from "../styles";
 
 import { useForceReloadData } from "../../contexts/ForceReloadData";
-
+// comment
 function RequestJson({
   dataRequest,
   url,

--- a/src/components/RequestJson/index.js
+++ b/src/components/RequestJson/index.js
@@ -44,7 +44,10 @@ function RequestJson({
   const IconButtonMain = type === "url" ? OpenInNewIcon : ContentCopyIcon;
 
   function handleOpenUrlNewWindow() {
-    window.open(urlGateway);
+    if (!disable) {
+      window.open(urlGateway);
+      setDisable(true);
+    }
   }
 
   function handleButtonAction() {
@@ -65,6 +68,7 @@ function RequestJson({
         </ContainerFlexWidthCustom>
         <ContainerFlexWidthCustom widthPercent={50}>
           <CustomButton
+            disabled={disable}
             endIcon={<IconButtonMain />}
             onClick={() => handleButtonAction()}
             style={{ width: "100%", textTransform: "none" }}

--- a/src/components/RequestJson/index.js
+++ b/src/components/RequestJson/index.js
@@ -20,7 +20,7 @@ import {
 import { ContainerRow } from "../styles";
 
 import { useForceReloadData } from "../../contexts/ForceReloadData";
-// comment de novo
+
 function RequestJson({
   dataRequest,
   url,

--- a/src/components/RequestJson/index.js
+++ b/src/components/RequestJson/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import "react-notifications/lib/notifications.css";
@@ -28,12 +28,17 @@ function RequestJson({
   type,
   ...rest
 }) {
+  const [disable, setDisable] = useState(false);
+
   function handleCopyToClipboard() {
-    const dataRequestJson = JSON.stringify({ ...dataRequest, url });
-    const textToCopy = type === "url" ? urlGateway : dataRequestJson;
-    copyToClipboard(textToCopy);
-    const textToNotification = type === "url" ? "Copied URL" : "JSON Copied";
-    NotificationManager.success(textToNotification, "", 1000);
+    if (!disable) {
+      const dataRequestJson = JSON.stringify({ ...dataRequest, url });
+      const textToCopy = type === "url" ? urlGateway : dataRequestJson;
+      copyToClipboard(textToCopy);
+      const textToNotification = type === "url" ? "Copied URL" : "JSON Copied";
+      NotificationManager.success(textToNotification, "", 1000);
+      setDisable(true);
+    }
   }
 
   const IconButtonMain = type === "url" ? OpenInNewIcon : ContentCopyIcon;
@@ -74,6 +79,7 @@ function RequestJson({
             style={{ marginLeft: 20, maxWidth: 140 }}
           >
             <CustomButton
+              disabled={disable}
               endIcon={<ContentCopyIcon />}
               onClick={() => handleCopyToClipboard()}
               style={{

--- a/src/contexts/forceReloadData.js
+++ b/src/contexts/forceReloadData.js
@@ -1,0 +1,29 @@
+import React, { createContext, useState, useContext } from "react";
+
+export const ForceReloadDataContext = createContext();
+
+export default function ForceReloadDataProvider({ children }) {
+  const [disable, setDisable] = useState(false);
+  //   const [highlightReload, setHighlightReload] = useState();
+
+  return (
+    <ForceReloadDataContext.Provider
+      value={{
+        disable,
+        setDisable,
+        // highlightReload,
+        // setHighlightReload,
+      }}
+    >
+      {children}
+    </ForceReloadDataContext.Provider>
+  );
+}
+
+export function useForceReloadData() {
+  const context = useContext(ForceReloadDataContext);
+  if (!context)
+    throw new Error("useDisable must be used within a ForceReloadDataProvider");
+  const { disable, setDisable } = context;
+  return { disable, setDisable };
+}


### PR DESCRIPTION
Ao usuário clicar em copiar URL ou abrir URL, os respectivos botões serão desabilitados até o usuário gerar novos dados.