### PR TITLE
Adiciona método para habilitar botões quando alterar dados no form

### DIFF
--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -119,6 +119,7 @@ function Form({
     const auto_approve = "1";
     // Toda vez que alterar algum dado no data
     setUrlGenerated(false);
+    setDisable(false);
 
     const isWithdraw = operation === operation_withdraw;
 


### PR DESCRIPTION
Ajuste realizado para habilitar botões de Copy Url e Open Url Gateway quando os dados do form forem alterados manualmente, sem necessidade de clicar no Reload Random Data

FRONT-314